### PR TITLE
docs: add server startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# API_ALTEVA
+
+## Running the server
+
+From the project root, start the FastAPI server with:
+
+```bash
+cd /workspace/API_ALTEVA
+uvicorn main:app --reload
+```
+
+If you run `uvicorn` from outside the project directory, include the full module path:
+
+```bash
+uvicorn API_ALTEVA.main:app
+```


### PR DESCRIPTION
## Summary
- document how to start the FastAPI server from project root
- note full module path needed when launching uvicorn outside project

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdae04eb90832193a2d4d5baf88661