### PR TITLE
Return login cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ uvicorn API_ALTEVA.main:app
 ## Endpoints
 
 - `/get_token` : récupère le token dynamique de la page de connexion.
-- `/login` (POST) : envoie `user`, `password` et `token` pour authentifier l'utilisateur.
+- `/login` (POST) : envoie `user`, `password` et `token` pour authentifier l'utilisateur et retourne les cookies envoyés par le serveur.

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ def get_token():
 
 @app.post("/login")
 def login(user: str, password: str, token: str):
-    """Envoie les identifiants de connexion et retourne la réponse brute."""
+    """Envoie les identifiants et retourne la réponse ainsi que les cookies."""
     url = f"https://www.m7.alteva.eu/emIsSIOn2/Page_Authentification/{token}"
     data = {
         "WD_JSON_PROPRIETE_": "{\"m_oProprietesSecurisees\":{},\"m_oChampsModifies\":{\"A22\":true,\"A23\":true},\"m_oVariablesProjet\":{},\"m_oVariablesPage\":{}}",
@@ -72,6 +72,15 @@ def login(user: str, password: str, token: str):
             timeout=10,
         )
         response.raise_for_status()
-        return {"response": response.text}
+
+        # Récupère les cookies renvoyés par le serveur
+        cookies = response.cookies.get_dict()
+        set_cookie = response.headers.get("set-cookie")
+
+        return {
+            "response": response.text,
+            "cookies": cookies,
+            "set_cookie": set_cookie,
+        }
     except Exception as e:
         return {"error": str(e)}


### PR DESCRIPTION
## Summary
- return server cookies and Set-Cookie header from `/login`
- update documentation for new login response

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1de2d5e7c83219261af591e5798cb