### PR TITLE
Return login and token cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ uvicorn API_ALTEVA.main:app
 
 ## Endpoints
 
-- `/get_token` : récupère le token dynamique de la page de connexion.
-- `/login` (POST) : envoie `user`, `password` et `token` pour authentifier l'utilisateur.
+- `/get_token` : récupère le token dynamique de la page de connexion et retourne les cookies envoyés par le serveur.
+- `/login` (POST) : envoie `user`, `password` et `token` pour authentifier l'utilisateur et retourne les cookies envoyés par le serveur.


### PR DESCRIPTION
## Summary
- return server cookies and Set-Cookie header from `/get_token` and `/login`
- update documentation for new token response

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1de2d5e7c83219261af591e5798cb